### PR TITLE
Fix backport printing for key instead of raw object

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -120,8 +120,8 @@ class Parentage(object):
 
     def sort(self, issues):
         def getkey(item):
-            if item in self.back:
-                return (Parentage.fixnum(self.back[item].key) + '/' +
+            if item.key in self.back:
+                return (Parentage.fixnum(self.back[item.key].key) + '/' +
                         Parentage.fixnum(item.key))
             else:
                 return Parentage.fixnum(item.key) + '~'

--- a/scan.py
+++ b/scan.py
@@ -189,7 +189,7 @@ def generate_table(issues, zephyr_base, release = False) -> str:
             continue
 
         if issue.issuetype() == "Backport":
-            issue.key += "\nB({})".format(issue.parent)
+            issue.key += "\nB({})".format(issue.parent.key)
 
         embargo = ""
         if issue.embargo != "":


### PR DESCRIPTION
The change:

    commit dbb4af7a477f2b0a42b43329df125514bad4b1b5
    Author: Flavio Ceolin <flavio.ceolin@intel.com>
    Date:   Mon Aug 31 10:56:34 2020 -0700

        scan: Generate release report

Changed the parent field to point to the parent object, not just the
key.  This causes the parent to print as a raw object.  Fix the printing
of the backport keys to print just the key.

Signed-off-by: David Brown <david.brown@linaro.org>